### PR TITLE
Update version of Otc.PubSub.Abtractions for 2.1.0 (dependency)

### DIFF
--- a/Source/Otc.PubSub.PunchySubscriber/Otc.PubSub.PunchySubscriber.csproj
+++ b/Source/Otc.PubSub.PunchySubscriber/Otc.PubSub.PunchySubscriber.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Otc.PubSub.Abstractions" Version="1.0.0-v100-alpha4-build36" />
+    <PackageReference Include="Otc.PubSub.Abstractions" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Alterando o versão do Otc.PubSub.Abtractions de 1.0.0-v100-alpha4-build36 para 2.1.0 devido a compatibilidade com as atualizações de versão dos pacotes Otc.PubSub.Abstraction e Otc.PubSub.Kafka